### PR TITLE
Fix deprecated np.math calls

### DIFF
--- a/fdsreader/bndf/obstruction.py
+++ b/fdsreader/bndf/obstruction.py
@@ -4,6 +4,7 @@ from typing import List, Dict, Tuple, Union, Sequence
 from typing_extensions import Literal
 import numpy as np
 
+
 from fdsreader.utils import Extent, Quantity, Dimension
 import fdsreader.utils.fortran_data as fdtype
 from fdsreader import settings
@@ -164,8 +165,8 @@ class Boundary:
         """Calculates the nearest timestep for which data has been output for this obstruction.
         """
         idx = np.searchsorted(self.times, time, side="left")
-        if time > 0 and (idx == len(self.times) or np.math.fabs(
-                time - self.times[idx - 1]) < np.math.fabs(time - self.times[idx])):
+        if time > 0 and (idx == len(self.times) or math.fabs(
+                time - self.times[idx - 1]) < math.fabs(time - self.times[idx])):
             return idx - 1
         else:
             return idx
@@ -275,7 +276,7 @@ class SubObstruction:
         if self.has_boundary_data:
             coords = self.get_coordinates()[orientation][dimension]
             idx = np.searchsorted(coords, value, side="left")
-            if idx > 0 and (idx == coords.size or np.math.fabs(value - coords[idx - 1]) < np.math.fabs(
+            if idx > 0 and (idx == coords.size or math.fabs(value - coords[idx - 1]) < math.fabs(
                     value - coords[idx])):
                 return idx - 1
             else:
@@ -485,8 +486,8 @@ class Obstruction:
                             mesh = subobst.mesh
                             mesh_coords = mesh.coordinates[dim]
                             idx = np.searchsorted(mesh_coords, single_coordinate, side="left")
-                            if idx > 0 and (idx == mesh_coords.size or np.math.fabs(
-                                    single_coordinate - mesh_coords[idx - 1]) < np.math.fabs(
+                            if idx > 0 and (idx == mesh_coords.size or math.fabs(
+                                    single_coordinate - mesh_coords[idx - 1]) < math.fabs(
                                 single_coordinate - mesh_coords[idx])):
                                 idx = idx + 1
                             if mesh_coords[idx] - single_coordinate < nearest_coordinate - single_coordinate:
@@ -503,7 +504,7 @@ class Obstruction:
         if self.has_boundary_data:
             coords = self.get_coordinates()[orientation][dimension]
             idx = np.searchsorted(coords, value, side="left")
-            if idx > 0 and (idx == coords.size or np.math.fabs(value - coords[idx - 1]) < np.math.fabs(
+            if idx > 0 and (idx == coords.size or math.fabs(value - coords[idx - 1]) < math.fabs(
                     value - coords[idx])):
                 return idx - 1
             else:
@@ -560,8 +561,8 @@ class Obstruction:
         if self.has_boundary_data:
             times = self.get_visible_times(self.times) if visible_only else self.times
             idx = np.searchsorted(times, time, side="left")
-            if time > 0 and (idx == len(times) or np.math.fabs(
-                    time - times[idx - 1]) < np.math.fabs(time - times[idx])):
+            if time > 0 and (idx == len(times) or math.fabs(
+                    time - times[idx - 1]) < math.fabs(time - times[idx])):
                 return idx - 1
             else:
                 return idx

--- a/fdsreader/fds_classes/mesh.py
+++ b/fdsreader/fds_classes/mesh.py
@@ -1,6 +1,7 @@
 from typing import Dict, Tuple, Sequence, List, Union
 from typing_extensions import Literal
 import numpy as np
+import math
 
 from fdsreader import settings
 from fdsreader.utils import Dimension, Extent, Quantity
@@ -101,7 +102,7 @@ class Mesh:
             if cell_centered:
                 coords = coords[:-1] + (coords[1] - coords[0]) / 2
             idx = np.searchsorted(coords, co, side="left")
-            if co > 0 and (idx == len(coords) or np.math.fabs(co - coords[idx - 1]) < np.math.fabs(
+            if co > 0 and (idx == len(coords) or math.fabs(co - coords[idx - 1]) < math.fabs(
                     co - coords[idx])):
                 ret.append(idx - 1)
             else:

--- a/fdsreader/isof/isosurface.py
+++ b/fdsreader/isof/isosurface.py
@@ -3,6 +3,7 @@ from functools import reduce
 from typing import BinaryIO, Dict, Union, List, Tuple, Optional
 
 import numpy as np
+import math
 
 from fdsreader.fds_classes import Mesh
 from fdsreader.utils import Quantity
@@ -337,8 +338,8 @@ class Isosurface:
         """Calculates the nearest timestep for which data has been output for this isosurface.
         """
         idx = np.searchsorted(self.times, time, side="left")
-        if time > 0 and (idx == len(self.times) or np.math.fabs(
-                time - self.times[idx - 1]) < np.math.fabs(time - self.times[idx])):
+        if time > 0 and (idx == len(self.times) or math.fabs(
+                time - self.times[idx - 1]) < math.fabs(time - self.times[idx])):
             return idx - 1
         else:
             return idx

--- a/fdsreader/slcf/geomslice.py
+++ b/fdsreader/slcf/geomslice.py
@@ -1,3 +1,4 @@
+import math
 import os
 from copy import deepcopy
 
@@ -285,8 +286,8 @@ class GeomSlice(np.lib.mixins.NDArrayOperatorsMixin):
         """Calculates the nearest timestep for which data has been output for this geomslice.
         """
         idx = np.searchsorted(self.times, time, side="left")
-        if time > 0 and (idx == len(self.times) or np.math.fabs(
-                time - self.times[idx - 1]) < np.math.fabs(time - self.times[idx])):
+        if time > 0 and (idx == len(self.times) or math.fabs(
+                time - self.times[idx - 1]) < math.fabs(time - self.times[idx])):
             return idx - 1
         else:
             return idx

--- a/fdsreader/slcf/slice.py
+++ b/fdsreader/slcf/slice.py
@@ -311,8 +311,8 @@ class Slice(np.lib.mixins.NDArrayOperatorsMixin):
         """Calculates the nearest timestep for which data has been output for this slice.
         """
         idx = np.searchsorted(self.times, time, side="left")
-        if time > 0 and (idx == len(self.times) or np.math.fabs(
-                time - self.times[idx - 1]) < np.math.fabs(time - self.times[idx])):
+        if time > 0 and (idx == len(self.times) or math.fabs(
+                time - self.times[idx - 1]) < math.fabs(time - self.times[idx])):
             return idx - 1
         else:
             return idx
@@ -322,7 +322,7 @@ class Slice(np.lib.mixins.NDArrayOperatorsMixin):
         """
         coords = self.get_coordinates()[dimension]
         idx = np.searchsorted(coords, value, side="left")
-        if idx > 0 and (idx == coords.size or np.math.fabs(value - coords[idx - 1]) < np.math.fabs(
+        if idx > 0 and (idx == coords.size or math.fabs(value - coords[idx - 1]) < math.fabs(
                 value - coords[idx])):
             return idx - 1
         else:
@@ -365,8 +365,8 @@ class Slice(np.lib.mixins.NDArrayOperatorsMixin):
                 for mesh in self._subslices.keys():
                     mesh_coords = mesh.coordinates[dim]
                     idx = np.searchsorted(mesh_coords, slice_coordinate, side="left")
-                    if idx > 0 and (idx == mesh_coords.size or np.math.fabs(
-                            slice_coordinate - mesh_coords[idx - 1]) < np.math.fabs(
+                    if idx > 0 and (idx == mesh_coords.size or math.fabs(
+                            slice_coordinate - mesh_coords[idx - 1]) < math.fabs(
                         slice_coordinate - mesh_coords[idx])):
                         idx = idx + 1
                     if mesh_coords[idx] - slice_coordinate < nearest_coordinate - slice_coordinate:


### PR DESCRIPTION
Replace np.math.fabs() calls with math.fabs() and
if necessary import the math module. Needed because
using numpy.math raises an error since the update
to numpy version 2.0.