### PR TITLE
Feature: Parse Device Activation Times

### DIFF
--- a/fdsreader/devc/device.py
+++ b/fdsreader/devc/device.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Union
+from typing import Tuple, Union, List
 
 from fdsreader.utils import Quantity
 
@@ -19,6 +19,7 @@ class Device:
         self.position = position
         self.orientation = orientation
         self._data_callback = lambda: None
+        self._activation_times: List[Tuple[float, bool]] | None = None
 
     @property
     def data(self):
@@ -47,6 +48,18 @@ class Device:
         """Alias for :class:`Device`.position.
         """
         return self.position
+    
+    @property
+    def activation_times(self):
+        """Alias for :class:`Device`._activation_times.
+        """
+        return self._activation_times
+    
+    def add_activation_time(self, activation: Tuple[float, bool]):
+        if self._activation_times == None:
+            self._activation_times = []
+        self._activation_times.append(activation)
+        self._activation_times.sort(key=lambda activation: activation[0]) # Sort the list of times by time
 
     def clear_cache(self):
         """Remove all data from the internal cache that has been loaded so far to free memory.

--- a/fdsreader/devc/device.py
+++ b/fdsreader/devc/device.py
@@ -19,7 +19,7 @@ class Device:
         self.position = position
         self.orientation = orientation
         self._data_callback = lambda: None
-        self._activation_times: List[Tuple[float, bool]] | None = None
+        self._activation_times: List[Tuple[float, bool]]= []
 
     @property
     def data(self):
@@ -61,8 +61,6 @@ class Device:
         Args:
             activation (Tuple[float, bool]): The activation time to track. Tuple should contain the time of activation (float) and the activation state (bool)
         """
-        if self._activation_times == None:
-            self._activation_times = []
         self._activation_times.append(activation)
         self._activation_times.sort(key=lambda activation: activation[0]) # Sort the list of times by time
 

--- a/fdsreader/devc/device.py
+++ b/fdsreader/devc/device.py
@@ -56,6 +56,11 @@ class Device:
         return self._activation_times
     
     def add_activation_time(self, activation: Tuple[float, bool]):
+        """Adds an activation time to the list of activation times
+
+        Args:
+            activation (Tuple[float, bool]): The activation time to track. Tuple should contain the time of activation (float) and the activation state (bool)
+        """
         if self._activation_times == None:
             self._activation_times = []
         self._activation_times.append(activation)

--- a/fdsreader/simulation.py
+++ b/fdsreader/simulation.py
@@ -23,7 +23,6 @@ import fdsreader.utils.fortran_data as fdtype
 from fdsreader import settings
 from fdsreader._version import __version__
 
-
 class Simulation:
     """Master class managing all data for a given simulation.
 
@@ -249,6 +248,17 @@ class Simulation:
                             self._devices[device_id] = [self._devices[device_id], device]
                     else:
                         self._devices[device_id] = device
+                elif keyword.startswith("DEVICE_ACT"):
+                    device_id = line.replace("DEVICE_ACT", "").strip()
+                    # Device should always be defined, as DEVICE_ACT appears after all DEVICE lines in smv
+                    device = self._devices[device_id]  
+                    
+                    data_line = smv_file.readline().strip()
+                    data = list(filter(None, data_line.split(" ")))
+                    
+                    _, time, value = data
+                    value = bool(int(value))
+                    device.add_activation_time((time, value))
                 elif keyword.startswith("SLC"):
                     self._load_slice(smv_file, keyword)
                 elif keyword.startswith("BNDS"):


### PR DESCRIPTION
This is a fairly simple feature that adds support for parsing the DEVICE_ACT line from the .smv file. The useful parts of this line contain a time and a state, and tracks when devices activate/deactivate. A single device can have many DEVICE_ACT lines referring to it.

This data is parsed and added to a new property in the Device class, and is stored as a list of tuples. Each tuple contains the time and the state.